### PR TITLE
Add home about section

### DIFF
--- a/src/app/components/green-button.tsx
+++ b/src/app/components/green-button.tsx
@@ -7,7 +7,7 @@ interface ButtonPropTypes {
 }
 
 const BUTTON_STYLE =
-  "bg-dark-green rounded-btn-radius font-btn-font-wgt text-primary-white px-6 py-3 md:text-btn-font-size text-[14px] shadow-md w-fit transition-all hover:bg-darkest-green";
+  "bg-dark-green rounded-btn-radius font-btn-font-wgt text-primary-white px-8 py-3 md:text-btn-font-size text-[14px] shadow-md w-fit transition-all hover:bg-darkest-green";
 
 const GreenButton: React.FC<ButtonPropTypes> = ({ label, href }) => {
   return (

--- a/src/app/components/green-button.tsx
+++ b/src/app/components/green-button.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Link from "next/link";
+
+interface ButtonPropTypes {
+  label: string;
+  href: string;
+}
+
+const BUTTON_STYLE =
+  "bg-dark-green rounded-btn-radius font-btn-font-wgt text-primary-white px-6 py-3 md:text-btn-font-size text-[14px] shadow-md w-fit transition-all hover:bg-darkest-green";
+
+const GreenButton: React.FC<ButtonPropTypes> = ({ label, href }) => {
+  return (
+    <Link href={href} className={BUTTON_STYLE}>
+      <button className="uppercase">{label}</button>
+    </Link>
+  );
+};
+
+export default GreenButton;

--- a/src/app/components/home/about-section.tsx
+++ b/src/app/components/home/about-section.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import GreenButton from "../green-button";
+
+const AboutSection = () => {
+  return (
+    <div className="bg-medium-green">
+      <div className="w-full h-screen flex ">
+        <div className="container mx-auto mb-40 flex items-center h-screen">
+          <div className="flex flex-col px-6 md:px-20 items-center gap-12">
+            <p className="text-primary-white text-center text-[24px] md:text-[32px] ">
+              Find Compassionate Care, Simplified.
+              <br />
+              Whether you’re searching for a reliable healthcare aid or looking
+              to offer your services, Care My Way makes the process effortless.
+              We provide a trusted platform where families can connect with
+              qualified healthcare aids who match your unique needs.
+            </p>
+            <GreenButton href="/" label="Find a Healthcare provider" />
+          </div>
+        </div>
+      </div>
+      //{" "}
+    </div>
+  );
+};
+
+export default AboutSection;

--- a/src/app/components/home/about-section.tsx
+++ b/src/app/components/home/about-section.tsx
@@ -19,7 +19,6 @@ const AboutSection = () => {
           </div>
         </div>
       </div>
-      //{" "}
     </div>
   );
 };

--- a/src/app/components/orange-button.tsx
+++ b/src/app/components/orange-button.tsx
@@ -7,7 +7,7 @@ interface ButtonPropTypes {
 }
 
 const BUTTON_STYLE =
-  "bg-primary-orange rounded-btn-radius font-btn-font-wgt text-primary-white px-6 py-3 md:text-btn-font-size text-[14px] shadow-md w-fit transition-all hover:bg-hover-orange";
+  "bg-primary-orange rounded-btn-radius font-btn-font-wgt text-primary-white px-8 py-3 md:text-btn-font-size text-[14px] shadow-md w-fit transition-all hover:bg-hover-orange";
 
 const OrangeButton: React.FC<ButtonPropTypes> = ({ label, href }) => {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { TopNavBar } from "@/app/components/top-navbar";
 import "@/app/globals.css";
 
 import HeroSection from "@/app/components/home/hero-section";
+import AboutSection from "@/app/components/home/about-section"; // Adjust the path as necessary
 
 export default function Home() {
   return (
@@ -10,6 +11,7 @@ export default function Home() {
         {/* Temp location of top navbar */}
         <TopNavBar />
         <HeroSection />
+        <AboutSection />
       </main>
     </div>
   );


### PR DESCRIPTION
This pull request introduces a new `GreenButton` component and integrates it into the `AboutSection` component on the homepage. Additionally, it includes a minor style adjustment to the `OrangeButton` component and updates the homepage to include the new `AboutSection`.

### New Component Addition:
Added a new `GreenButton` component with styles and props for `label` and `href`.

### Component Integration:
Created a new `AboutSection` component that uses the `GreenButton` component.
Imported and included the `AboutSection` component in the homepage. 

### Style Adjustment:
Adjusted padding in the `OrangeButton` component's style.